### PR TITLE
Correct paths to css files in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Leaflet Turn By Turn By Mapzen Example</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
-    <link rel="stylesheet" href="../dist/leaflet.routing.mapzen.css" />
+    <link rel="stylesheet" href="../dist/lrm-mapzen.css" />
 </head>
 <body>
     <div id="map"></div>

--- a/examples/transit.html
+++ b/examples/transit.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Leaflet Turn By Turn By Mapzen Example</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
-    <link rel="stylesheet" href="../dist/leaflet.routing.mapzen.css" />
+    <link rel="stylesheet" href="../dist/lrm-mapzen.css" />
 </head>
 <body>
     <div id="map"></div>


### PR DESCRIPTION
Hi, 

Both html files in examples/ have an incorrect file path to the css files and as a result, the examples won't load in a browser. They are pointing to an old file name (../dist/leaflet.routing.mapzen.css) instead of ..dist/lrm-mapzen.css  This renaming occurred in [https://github.com/mapzen/lrm-mapzen/commit/b29b94fcb58a082b2aad957e995ac30c4502fa40] . 
 
This pull request correct the path/file name to the current location (in dist/) of the CSS file in mapzen's lrm-mapzen repository. 

For consistency and eliminate confusion, you may want to also rename the leaflet.routing.mapzen.css which is in ..css/ to the same file syntax as most of the other lrm files in this repository - lrm-mapzen.css